### PR TITLE
Make fit code externally callable

### DIFF
--- a/python/BinnedFit.py
+++ b/python/BinnedFit.py
@@ -14,7 +14,7 @@ from PlotFit import setStyle,print1DProj,print2DScatter,get3DHistoFrom1D,getBinE
 
 densityCorr = False
 
-def binnedFit(pdf, data, fitRange='Full',useWeight=False):
+def binnedFit(pdf, data, fitRange='Full',useWeight=False, box='MultiJet'):
 
     if useWeight:
         fr = pdf.fitTo(data,rt.RooFit.Range(fitRange),rt.RooFit.Extended(True),rt.RooFit.SumW2Error(True),rt.RooFit.Save(),rt.RooFit.Minimizer('Minuit2','migrad'),rt.RooFit.Strategy(2))
@@ -266,7 +266,7 @@ if __name__ == '__main__':
     elif noFit:
         fr = rt.RooFitResult()
     else:
-        fr = binnedFit(extRazorPdf,dataHist,sideband,options.useWeight)
+        fr = binnedFit(extRazorPdf,dataHist,sideband,options.useWeight,box=box)
         total = extRazorPdf.expectedEvents(rt.RooArgSet(th1x))
         nll = 0
         iBinX = -1

--- a/python/PlotFit.py
+++ b/python/PlotFit.py
@@ -780,7 +780,7 @@ def print1DProj(c,rootFile,h,h_data,printName,xTitle,yTitle,lumiLabel="",boxLabe
     c.Write(os.path.splitext(printName)[0].split('/')[-1])
 
     
-def print1DProjNs(c,rootFile,h,h_data,h_ns,printName,xTitle,yTitle,lumiLabel="",boxLabel="",plotLabel="",isData=False,doSignalInj=False,options=None,tLeg=None,h_components=[],h_colors=[],h_labels=[]):
+def print1DProjNs(c,rootFile,h,h_data,h_ns,printName,xTitle,yTitle,lumiLabel="",boxLabel="",plotLabel="",isData=False,doSignalInj=False,options=None,tLeg=None,h_components=[],h_colors=[],h_labels=[],cfg=None):
     
     if densityCorr:
         h_densitycorr = densityCorrect(h)
@@ -2003,9 +2003,9 @@ if __name__ == '__main__':
                 print1DProj(c,tdirectory,h_Rsq_components[k],h_data_Rsq_components[k],options.outDir+"/h_Rsq_%ibtag_%s.pdf"%(z[k],box),"R^{2}",eventsLabel,lumiLabel,newBoxLabel,plotLabel,options.isData)
             if computeErrors:
                 if doSignalInj:
-                    print1DProjNs(c,tdirectory,h_th1x_components[k],h_data_th1x_components[k],h_RsqMR_nsigma_components[k],options.outDir+"/h_th1x_ns_%ibtag_%s.pdf"%(z[k],box),"Bin Number",eventsLabel,lumiLabel,newBoxLabel,plotLabel,options.isData,doSignalInj,options,None,[h_sig_th1x_components[k]])
+                    print1DProjNs(c,tdirectory,h_th1x_components[k],h_data_th1x_components[k],h_RsqMR_nsigma_components[k],options.outDir+"/h_th1x_ns_%ibtag_%s.pdf"%(z[k],box),"Bin Number",eventsLabel,lumiLabel,newBoxLabel,plotLabel,options.isData,doSignalInj,options,None,[h_sig_th1x_components[k]], cfg=cfg)
                 else:
-                    print1DProjNs(c,tdirectory,h_th1x_components[k],h_data_th1x_components[k],h_RsqMR_nsigma_components[k],options.outDir+"/h_th1x_ns_%ibtag_%s.pdf"%(z[k],box),"Bin Number",eventsLabel,lumiLabel,newBoxLabel,plotLabel,options.isData,doSignalInj,options)
+                    print1DProjNs(c,tdirectory,h_th1x_components[k],h_data_th1x_components[k],h_RsqMR_nsigma_components[k],options.outDir+"/h_th1x_ns_%ibtag_%s.pdf"%(z[k],box),"Bin Number",eventsLabel,lumiLabel,newBoxLabel,plotLabel,options.isData,doSignalInj,options, cfg=cfg)
                 print2DResiduals(c,tdirectory,h_RsqMR_nsigma_components[k],options.outDir+"/h_RsqMR_nsigma_log_%ibtag_%s.pdf"%(z[k],box),"M_{R} [GeV]", "R^{2}", "Stat.+Sys. n#sigma",lumiLabel,newBoxLabel,plotLabel,x,y,options.isData,sidebandFit,doSignalInj,options)
             else:                
                 if doSignalInj:

--- a/python/RunToys.py
+++ b/python/RunToys.py
@@ -276,9 +276,9 @@ def runToys(w,options,cfg,seed):
     #c.Print(varName+varName2+'.2pdf')
     #sys.exit()
                 
-    if options.box == 'MultiJet':
+    if options.box in ['MultiJet','DiJet']:
         xFactor = [1.8, 1.4, 1.4, 1.4] #xFactor for each b-tag bin
-    elif options.box == 'MuMultiJet':
+    elif options.box in ['MuMultiJet', 'LeptonMultiJet', 'LeptonJet']:
         xFactor = [2.0, 2.0, 2.0, 2.0] #xFactor for each b-tag bin
     elif options.box == 'EleMultiJet':
         xFactor = [2.0, 1.8, 1.2, 1.2] #xFactor for each b-tag bin

--- a/python/macro/razorFits.py
+++ b/python/macro/razorFits.py
@@ -232,7 +232,7 @@ class FitInstance(object):
         for k in range(0, len(self.z)-1):
             entries = self.workspace.data("RMRTree").sumEntries(
                     "nBtag>=%i && nBtag<%i"%(self.z[k], self.z[k+1]))
-            par = "Ntot_TTj%db_MultiJet"%self.z[k]
+            par = "Ntot_TTj%db_%s"%(self.z[k],self.analysis.region)
             print "Resetting fit parameter %s to %d"%(par, entries)
             self.workspace.var(par).setVal(entries)
 


### PR DESCRIPTION
This PR makes it possible to import binnedFit(), runToys(), etc, and use them in other scripts, while keeping the existing functionality.